### PR TITLE
remove minivariant reference in default layout

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,6 @@
   <v-app :dark="darkTheme">
     <v-navigation-drawer
       v-model="drawer"
-      :mini-variant="miniVariant"
       :clipped="clipped"
       fixed
       app


### PR DESCRIPTION
This PR removes miniVariant reference left in default layout which was missed in #1 