### PR TITLE
Test for unsplashWrapper

### DIFF
--- a/server/services/imageRandom.test.js
+++ b/server/services/imageRandom.test.js
@@ -5,7 +5,7 @@ describe('ImageRandom.service', () => {
     expect(fetchRandomImage).toBeDefined()
   })
 
-  it('should be able to retrieve  a random image', async () => {
+  it('should be able to retrieve a random image', async () => {
     const image = await fetchRandomImage()
     const imageSecond = await fetchRandomImage()
     expect(image.id).toBeDefined()

--- a/server/utils/unsplashWrapper.test.js
+++ b/server/utils/unsplashWrapper.test.js
@@ -1,0 +1,18 @@
+import unsplashWrapper from './unsplashWrapper'
+
+describe('UnsplashWrapper', () => {
+  it('should be defined', () => {
+    expect(unsplashWrapper).toBeDefined()
+  })
+
+  it('should contain expected properties inside the wrapper', () => {
+    expect(unsplashWrapper).toHaveProperty('unsplash')
+    expect(unsplashWrapper).toHaveProperty('toJson')
+  })
+
+  it('should contain a properly instance of unsplash with application id and secret', () => {
+    const { unsplash } = unsplashWrapper
+    expect(unsplash).toHaveProperty('_applicationId')
+    expect(unsplash).toHaveProperty('_secret')
+  })
+})


### PR DESCRIPTION
This PR adds a simple test for unsplashWrapper
* Test that the wrapper has expected properties
* Test that the wrapper contains a properly instance of unsplash with needed application and secret keys

Also fixed a typo in imageRandom test