### PR TITLE
Improve parserImages to use parserImage internally instead of creating ImagePalettes of it's own

### DIFF
--- a/utils/parsers/parserImages.js
+++ b/utils/parsers/parserImages.js
@@ -1,11 +1,11 @@
-import ImagePalette from '../ImagePalette'
+import parserImage from './parserImage'
 
 /**
- * Parse images response data as ImagePalette classes
+ * Parse images response data. Uses parserImage method to parse multiple images as ImagePalette classes
  * @param {Object} data
  * @returns {Array[ImagePalette]}
  */
-export default function parserImage(data) {
+export default function parserImages(data) {
   if (!data) {
     return []
   }
@@ -15,7 +15,7 @@ export default function parserImage(data) {
     ? localData.results
     : createImageArray(localData)
 
-  const imagePalettes = images.map(image => new ImagePalette(image))
+  const imagePalettes = images.map(image => parserImage(image))
   return imagePalettes
 }
 


### PR DESCRIPTION
This PR includes a fix in parserImages in which it is now using parserImage internally and to parse multiple images instead of using ImagePalette class directly. 

This means that all images, single or multiple are flowing through the same parser which actually creates the image palette class from image data