### PR TITLE
Add two api methods to get latest and popular images easily

### DIFF
--- a/utils/API.js
+++ b/utils/API.js
@@ -73,6 +73,28 @@ class API {
     }
     return this.request(this._url('images/list'), config)
   }
+
+  /**
+   * Get latest images in a list
+   * @param {Object} param0
+   * @param {Number=} [param0.page=1] Result page to get
+   * @param {Number=} [param0.perPage=10] Result size to get
+   * @returns {Promise}
+   */
+  getImagesLatest({ page = 1, perPage = 10 } = {}) {
+    return this.getImagesList({ page, perPage, orderBy: 'latest' })
+  }
+
+  /**
+   * Get popular images in a list
+   * @param {Object} param0
+   * @param {Number=} [param0.page=1] Result page to get
+   * @param {Number=} [param0.perPage=10] Result size to get
+   * @returns {Promise}
+   */
+  getImagesPopular({ page = 1, perPage = 10 } = {}) {
+    return this.getImagesList({ page, perPage, orderBy: 'popular' })
+  }
   /**
    * Return api endpoint with base endpoint prefixed
    * @param {String} url


### PR DESCRIPTION
This PR adds two methods to API class:
* `getImagesLatest({ page, perPage })` to easily fetch latest images
* `getImagesPopular({ page, perPage })` to easily fetch popular images

These two methods can be used on a start page or something instead of using `getImagesList` method where you specify the sort order manually between latest, oldest and popular