### PR TITLE
Added Global component registration plugin and split up main layout into core components

### DIFF
--- a/components/core/Footer.vue
+++ b/components/core/Footer.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-footer
+    :fixed="fixedFooter"
+    app
+  >
+    <span>&copy; 2019</span>
+  </v-footer>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      fixedFooter: true
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/components/core/MenuSettings.vue
+++ b/components/core/MenuSettings.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-menu bottom left nudge-left="20" nudge-bottom="20" :close-on-content-click="false">
+    <v-btn
+      slot="activator"
+      icon
+    >
+      <v-icon>settings</v-icon>
+    </v-btn>
+    <v-list two-line subheader>
+      <v-subheader>Customizations</v-subheader>
+      <v-list-tile>
+        <v-list-tile-action>
+          <v-switch color="primary" @change="onThemeChange" />
+        </v-list-tile-action>
+        <v-list-tile-title>Dark theme</v-list-tile-title>
+      </v-list-tile>
+    </v-list>
+  </v-menu>
+</template>
+
+<script>
+export default {
+  methods: {
+    onThemeChange(evt) {
+      // TODO: Hook up vuex to change theme
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -1,0 +1,67 @@
+<template>
+  <div>
+    <v-navigation-drawer
+      v-model="drawer"
+      :clipped="clipped"
+      fixed
+      app
+      :temporary="temporary"
+    >
+      <v-list>
+        <v-list-tile
+          v-for="(item, i) in items"
+          :key="i"
+          :to="item.to"
+          router
+          exact
+        >
+          <v-list-tile-action>
+            <v-icon>{{ item.icon }}</v-icon>
+          </v-list-tile-action>
+          <v-list-tile-content>
+            <v-list-tile-title v-text="item.title" />
+          </v-list-tile-content>
+        </v-list-tile>
+      </v-list>
+    </v-navigation-drawer>
+    <v-toolbar
+      :clipped-left="clipped"
+      fixed
+      app
+    >
+      <v-toolbar-side-icon @click="drawer = !drawer" />
+      <v-toolbar-title v-text="title" />
+      <v-spacer />
+      <core-menu-settings />
+    </v-toolbar>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      clipped: true,
+      drawer: false,
+      temporary: true,
+      darkTheme: false,
+      title: 'Color Splash',
+      items: [
+        {
+          icon: 'apps',
+          title: 'Home',
+          to: '/'
+        },
+        {
+          icon: 'bubble_chart',
+          title: 'About',
+          to: '/about'
+        }
+      ]
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,72 +1,12 @@
 <template>
   <v-app :dark="darkTheme">
-    <v-navigation-drawer
-      v-model="drawer"
-      :clipped="clipped"
-      fixed
-      app
-    >
-      <v-list>
-        <v-list-tile
-          v-for="(item, i) in items"
-          :key="i"
-          :to="item.to"
-          router
-          exact
-        >
-          <v-list-tile-action>
-            <v-icon>{{ item.icon }}</v-icon>
-          </v-list-tile-action>
-          <v-list-tile-content>
-            <v-list-tile-title v-text="item.title" />
-          </v-list-tile-content>
-        </v-list-tile>
-      </v-list>
-    </v-navigation-drawer>
-    <v-toolbar
-      :clipped-left="clipped"
-      fixed
-      app
-    >
-      <v-toolbar-side-icon @click="drawer = !drawer" />
-      <v-toolbar-title v-text="title" />
-      <v-spacer />
-      <v-menu bottom left nudge-left="20" nudge-bottom="20" :close-on-content-click="false">
-        <v-btn
-          slot="activator"
-          icon
-        >
-          <v-icon>settings</v-icon>
-        </v-btn>
-        <v-list two-line subheader>
-          <v-subheader>Settings</v-subheader>
-          <v-list-tile avatar>
-            <v-list-tile-content>
-              <v-list-tile-title> To be defined</v-list-tile-title>
-              <v-list-tile-sub-title>TO be defined</v-list-tile-sub-title>
-            </v-list-tile-content>
-          </v-list-tile>
-          <v-subheader>Customizations</v-subheader>
-          <v-list-tile>
-            <v-list-tile-action>
-              <v-switch v-model="darkTheme" color="primary" />
-            </v-list-tile-action>
-            <v-list-tile-title>Dark theme</v-list-tile-title>
-          </v-list-tile>
-        </v-list>
-      </v-menu>
-    </v-toolbar>
+    <core-navigation-drawer />
     <v-content>
       <v-container>
         <nuxt />
       </v-container>
     </v-content>
-    <v-footer
-      :fixed="fixedFooter"
-      app
-    >
-      <span>&copy; 2019</span>
-    </v-footer>
+    <core-footer />
   </v-app>
 </template>
 
@@ -74,23 +14,7 @@
 export default {
   data() {
     return {
-      clipped: true,
-      drawer: false,
-      fixedFooter: true,
-      darkTheme: false,
-      items: [
-        {
-          icon: 'apps',
-          title: 'Home',
-          to: '/'
-        },
-        {
-          icon: 'bubble_chart',
-          title: 'About',
-          to: '/about'
-        }
-      ],
-      title: 'Color Splash'
+      darkTheme: false
     }
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -37,7 +37,11 @@ module.exports = {
   /*
   ** Plugins to load before mounting the App
   */
-  plugins: ['@/plugins/vuetify', '@/plugins/api'],
+  plugins: [
+    '@/plugins/vuetify',
+    '@/plugins/api',
+    '@/plugins/componentRegistration'
+  ],
 
   /*
   ** Nuxt.js modules

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "es6-promise": "^4.2.6",
     "express": "^4.16.4",
     "isomorphic-fetch": "^2.2.1",
+    "lodash": "^4.17.11",
     "node-vibrant": "^3.2.0-alpha",
     "nuxt": "^2.6.1",
     "unsplash-js": "^5.0.0",

--- a/plugins/componentRegistration.js
+++ b/plugins/componentRegistration.js
@@ -1,0 +1,15 @@
+import Vue from 'vue'
+import upperFirst from 'lodash/upperFirst'
+import camelCase from 'lodash/camelCase'
+
+const requireComponent = require.context('@/components', true, /\.vue$/)
+
+requireComponent.keys().forEach(fileName => {
+  const componentConfig = requireComponent(fileName)
+
+  const componentName = upperFirst(
+    camelCase(fileName.replace(/^\.\//, '').replace(/\.\w+$/, ''))
+  )
+
+  Vue.component(componentName, componentConfig.default || componentConfig)
+})


### PR DESCRIPTION
This PR adds a new plugin which globally registers all components in `@/components` folder. This plugin will also look in subfolders and use folder/filenames to register the components. 

This plugin will come in handy to reduce code noice when using the components since they won't have to be included in each file they are to be used.

This PR also splits up the main layout in to basic dumb core components. Dark mode toggle is yet to be implemented via vuex store action/mutation and should be done in a seperate PR to introduce a vuex store

**TLDR:**
* Add plugin to globally register components
* Split up main layout into `/components/core/*.vue` components