### PR TITLE
Search result page and search box in top navigation

### DIFF
--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -45,7 +45,7 @@ export default {
     return {
       clipped: true,
       drawer: false,
-      temporary: true,
+      temporary: false,
       darkTheme: false,
       title: 'Color Splash',
       items: [

--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -32,6 +32,8 @@
       <v-toolbar-side-icon @click="drawer = !drawer" />
       <v-toolbar-title v-text="title" />
       <v-spacer />
+      <core-search-field />
+      <v-spacer />
       <core-menu-settings />
     </v-toolbar>
   </div>

--- a/components/core/SearchField.vue
+++ b/components/core/SearchField.vue
@@ -5,6 +5,9 @@
     single-line
     append-icon="search"
     class="searchbar"
+    hide-details
+    box
+    full-width
     @click:append="search"
     @keyup.enter="search"
   />
@@ -29,7 +32,6 @@ export default {
 </script>
 
 <style lang="stylus">
-.searchbar .v-input__slot
-  margin-bottom: 0px
+
 
 </style>

--- a/components/core/SearchField.vue
+++ b/components/core/SearchField.vue
@@ -18,11 +18,11 @@ export default {
     }
   },
   mounted() {
-    this.input = this.$route.query.query || ''
+    this.input = this.$route.query.keyword || ''
   },
   methods: {
     search() {
-      this.$router.push({ name: 'search', query: { query: this.input } })
+      this.$router.push({ name: 'search', query: { keyword: this.input } })
     }
   }
 }

--- a/components/core/SearchField.vue
+++ b/components/core/SearchField.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-text-field
+    v-model="input"
+    label="Search..."
+    single-line
+    append-icon="search"
+    class="searchbar"
+    @click:append="search"
+    @keyup.enter="search"
+  />
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      input: ''
+    }
+  },
+  mounted() {
+    this.input = this.$route.query.query || ''
+  },
+  methods: {
+    search() {
+      this.$router.push({ name: 'search', query: { query: this.input } })
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+.searchbar .v-input__slot
+  margin-bottom: 0px
+
+</style>

--- a/components/image/FetchButton.vue
+++ b/components/image/FetchButton.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-btn
+    :loading="loading"
+    round
+    flat
+    outline
+    color="primary"
+    @click="fetch"
+  >
+    {{ text }}
+  </v-btn>
+</template>
+
+<script>
+export default {
+  props: {
+    text: {
+      type: String,
+      default: 'Load more'
+    },
+    page: {
+      type: Number,
+      default: 2
+    },
+    perPage: {
+      type: Number,
+      default: 10
+    },
+    loading: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      internalPage: this.page
+    }
+  },
+  methods: {
+    fetch() {
+      this.$emit('fetch', { page: this.internalPage, perPage: this.perPage })
+      this.stepPage()
+    },
+    stepPage() {
+      this.internalPage += 1
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+
+</style>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -13,7 +13,7 @@
       </v-flex>
     </v-layout>
 
-    <v-layout align-center justify-center>
+    <v-layout v-if="hasImages" align-center justify-center>
       <image-fetch-button :loading="loadingImages" @fetch="loadMore" />
     </v-layout>
   </div>
@@ -30,6 +30,9 @@ export default {
   computed: {
     keyword() {
       return this.$route.query.keyword
+    },
+    hasImages() {
+      return this.images.length > 0
     }
   },
   watch: {

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,0 +1,64 @@
+<template>
+  <div>
+    <v-layout align-start row wrap>
+      <v-flex
+        v-for="(image, index) in images"
+        :key="index + image.id"  
+        xl4
+        md6
+        xs12
+        pa-4
+      >
+        <image-card :image="image" />
+      </v-flex>
+    </v-layout>
+
+    <v-layout align-center justify-center>
+      <image-fetch-button :loading="loadingImages" @fetch="loadMore" />
+    </v-layout>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      images: [],
+      loadingImages: false
+    }
+  },
+  computed: {
+    keyword() {
+      return this.$route.query.keyword
+    }
+  },
+  watch: {
+    async $route(to, from) {
+      const keyword = to.query.keyword
+      this.images = await this.getImagesByKeyword({ keyword })
+    }
+  },
+  async mounted() {
+    this.images = await this.getImagesByKeyword({
+      keyword: this.keyword
+    })
+  },
+  methods: {
+    async getImagesByKeyword({ keyword, page = 1, perPage }) {
+      // TODO: Use real api request for fetching images by keyword
+      const { data } = await this.$api.getMockDataImageList()
+      return data
+    },
+    async loadMore({ page, perPage }) {
+      this.loadingImages = true
+      const newImages = await this.getImagesByKeyword({
+        page,
+        perPage,
+        keyword: this.keyword
+      })
+      this.images.push(...newImages)
+      this.loadingImages = false
+    }
+  }
+}
+</script>

--- a/plugins/vuetify.js
+++ b/plugins/vuetify.js
@@ -4,7 +4,7 @@ import colors from 'vuetify/es5/util/colors'
 
 Vue.use(Vuetify, {
   theme: {
-    primary: colors.blue.darken2,
+    primary: colors.pink.accent2,
     accent: colors.grey.darken3,
     secondary: colors.amber.darken3,
     info: colors.teal.lighten1,


### PR DESCRIPTION
This PR adds a search result page (which for now user mock API data) which will search for whatever keyword is in the route query param "keyword".

Setting the query param and routing to the search result page is done through a new universal core search field component which is used in the core top navigation bar.

* Added search result page (with mock data for now)
* Added core search field component that will take search input and change route to search result page
* Added "Load more" button that emits event that pages can listen for to fetch more images. This component is responsible for determine what page is to be fetched.
* Changed default color to pink-ish