### PR TITLE
Added page to display popular images and added mdi icons

### DIFF
--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -50,12 +50,17 @@ export default {
       title: 'Color Splash',
       items: [
         {
-          icon: 'apps',
+          icon: 'mdi-home',
           title: 'Home',
           to: '/'
         },
         {
-          icon: 'bubble_chart',
+          icon: 'mdi-fire',
+          title: 'Popular',
+          to: '/popular'
+        },
+        {
+          icon: 'mdi-information-outline',
           title: 'About',
           to: '/about'
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1616,6 +1616,12 @@
         "core-js": "^2.5.7"
       }
     },
+    "@mdi/font": {
+      "version": "3.6.95",
+      "resolved": "https://registry.npmjs.org/@mdi/font/-/font-3.6.95.tgz",
+      "integrity": "sha512-wUbkF/RRCIh51TPzAL9qUeRSUFla9I3x1nGq62HkfWzIebRHbDY5HPaYCQuZO7398dWaLHTu4BwnBA58YbhfEA==",
+      "dev": true
+    },
     "@nuxt/babel-preset-app": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@nuxt/babel-preset-app/-/babel-preset-app-2.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "vuetify-loader": "^1.2.0"
   },
   "devDependencies": {
+    "@mdi/font": "^3.6.95",
     "@nuxtjs/eslint-config": "^0.0.1",
     "@vue/test-utils": "^1.0.0-beta.27",
     "babel-core": "7.0.0-bridge.0",

--- a/pages/popular.vue
+++ b/pages/popular.vue
@@ -1,0 +1,57 @@
+<template>
+  <div>
+    <v-layout align-start row wrap>
+      <v-flex
+        v-for="(image, index) in images"
+        :key="index + image.id"  
+        xl4
+        md6
+        xs12
+        pa-4
+      >
+        <image-card :image="image" />
+      </v-flex>
+    </v-layout>
+
+    <v-layout v-if="hasImages" align-center justify-center>
+      <image-fetch-button :loading="loadingImages" @fetch="loadMore" />
+    </v-layout>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      images: [],
+      loadingImages: false
+    }
+  },
+  computed: {
+    hasImages() {
+      return this.images.length > 0
+    }
+  },
+  async mounted() {
+    this.images = await this.getImages({
+      keyword: this.keyword
+    })
+  },
+  methods: {
+    async getImages({ page = 1, perPage }) {
+      // TODO: Use real api request for fetching images by keyword
+      const { data } = await this.$api.getMockDataImageList()
+      return data
+    },
+    async loadMore({ page, perPage }) {
+      this.loadingImages = true
+      const newImages = await this.getImages({
+        page,
+        perPage
+      })
+      this.images.push(...newImages)
+      this.loadingImages = false
+    }
+  }
+}
+</script>

--- a/plugins/vuetify.js
+++ b/plugins/vuetify.js
@@ -1,8 +1,10 @@
 import Vue from 'vue'
 import Vuetify from 'vuetify/lib'
 import colors from 'vuetify/es5/util/colors'
+import '@mdi/font/css/materialdesignicons.css' // Ensure you are using css-loader
 
 Vue.use(Vuetify, {
+  iconfont: 'mdi',
   theme: {
     primary: colors.pink.accent2,
     accent: colors.grey.darken3,


### PR DESCRIPTION
This PR adds a new popular.vue page which is to be used to display popular images. For now image data is mocked.
This PR also adds mdi icon font which has alot more icons to choose from than the default icon lib shipped with vuetify.
* New popular page
* New icon font 