### PR TITLE
Refactor popular page into dynamic image list page that responds to query param

### DIFF
--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -65,7 +65,7 @@ export default {
           to: { path: '/list', query: { orderBy: 'latest' } }
         },
         {
-          icon: 'mdi-information-outline',
+          icon: 'mdi-information-variant',
           title: 'About',
           to: '/about'
         }

--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -57,7 +57,12 @@ export default {
         {
           icon: 'mdi-fire',
           title: 'Popular',
-          to: '/popular'
+          to: { path: '/list', query: { orderBy: 'popular' } }
+        },
+        {
+          icon: 'mdi-clock-outline',
+          title: 'Latest',
+          to: { path: '/list', query: { orderBy: 'latest' } }
         },
         {
           icon: 'mdi-information-outline',

--- a/pages/list.vue
+++ b/pages/list.vue
@@ -28,26 +28,43 @@ export default {
     }
   },
   computed: {
+    orderBy() {
+      return this.$route.query.orderBy
+    },
+    pageTitle() {
+      return this.orderBy.charAt(0).toUpperCase() + this.orderBy.slice(1)
+    },
     hasImages() {
       return this.images.length > 0
     }
   },
+  watch: {
+    async $route(to, from) {
+      const orderBy = to.query.orderBy
+      this.images = await this.getImagesList({ orderBy })
+    }
+  },
   async mounted() {
-    this.images = await this.getImages({
-      keyword: this.keyword
+    this.images = await this.getImagesList({
+      orderBy: this.orderBy
     })
   },
   methods: {
-    async getImages({ page = 1, perPage }) {
+    async getImagesList({ page = 1, perPage, orderBy }) {
       // TODO: Use real api request for fetching images by keyword
-      const { data } = await this.$api.getMockDataImageList()
+      const { data } = await this.$api.getMockDataImageList({
+        page,
+        perPage,
+        orderBy
+      })
       return data
     },
     async loadMore({ page, perPage }) {
       this.loadingImages = true
-      const newImages = await this.getImages({
+      const newImages = await this.getImagesList({
         page,
-        perPage
+        perPage,
+        orderBy: this.orderBy
       })
       this.images.push(...newImages)
       this.loadingImages = false


### PR DESCRIPTION
This PR refactors popular page to a general and dynamic image list page which is to be used to get either popular, latest or oldest images via API endpoint.

* Added dynamic image page to avoid duplicate page of "latest" and "popular" images where the only differense is a `orderBy` param that can be sent to API method to get different image lists