### PR TITLE
Add copy to clipboard component

### DIFF
--- a/components/color/ClipboardCopy.vue
+++ b/components/color/ClipboardCopy.vue
@@ -1,0 +1,48 @@
+<template>
+  <div @mouseleave="resetToolTip">
+    <v-tooltip bottom>
+      <template v-slot:activator="{ on }">
+        <v-btn color="grey darken-1" flat icon @click="copyToClipBoard" v-on="on">
+          <v-icon>content_copy</v-icon>
+        </v-btn>
+      </template>
+      <span>{{ tooltipText }}</span>
+    </v-tooltip>
+  </div>
+</template>
+
+<script>
+import copy from 'copy-to-clipboard'
+
+export default {
+  props: {
+    colors: {
+      type: Array,
+      default: () => []
+    }
+  },
+  data() {
+    return {
+      tooltipText: 'Copy colors to clipboard'
+    }
+  },
+  methods: {
+    copyToClipBoard() {
+      copy(this.colors)
+      this.tooltipText = 'Copied to clipboard'
+    },
+    resetToolTip() {
+      setTimeout(() => {
+        this.tooltipText = this.getDefaultToolTipText()
+      }, 500)
+    },
+    getDefaultToolTipText() {
+      return 'Copy colors to clipboard'
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+
+</style>

--- a/components/color/Slider.vue
+++ b/components/color/Slider.vue
@@ -60,12 +60,6 @@ export default {
     hexValues() {
       return this.colors.map(color => color[this.type](this.sliderLevel).hex())
     }
-  },
-  methods: {
-    copyToClipboard() {
-      // eslint-disable-next-line no-console
-      console.log('Copy')
-    }
   }
 }
 </script>

--- a/components/color/Slider.vue
+++ b/components/color/Slider.vue
@@ -1,15 +1,17 @@
 <template>
   <div>
     <color-boxes :colors="hexValues" size="45px" :hover-effect="hoverEffect" />
-    <v-slider
-      v-model="sliderLevel"
-      :label="label"
-      :max="max"
-      :min="min"
-      thumb-label
-      :ticks="ticks"
-      append-icon="copy"
-    />
+    <v-layout align-baseline>
+      <v-slider
+        v-model="sliderLevel"
+        :label="label"
+        :max="max"
+        :min="min"
+        thumb-label
+        :ticks="ticks"
+      />
+      <color-clipboard-copy :colors="hexValues" />
+    </v-layout>
   </div>
 </template>
 
@@ -57,6 +59,12 @@ export default {
   computed: {
     hexValues() {
       return this.colors.map(color => color[this.type](this.sliderLevel).hex())
+    }
+  },
+  methods: {
+    copyToClipboard() {
+      // eslint-disable-next-line no-console
+      console.log('Copy')
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4971,6 +4971,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz",
+      "integrity": "sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
@@ -13961,6 +13969,11 @@
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "topo": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@nuxtjs/axios": "^5.3.6",
     "@nuxtjs/pwa": "^2.6.0",
     "chroma-js": "^2.0.3",
+    "copy-to-clipboard": "^3.2.0",
     "cross-env": "^5.2.0",
     "dotenv": "^6.2.0",
     "es6-promise": "^4.2.6",


### PR DESCRIPTION
This PR adds the `components/colors/CopyToClipBoard.vue` component that takes colors as hex value props and copies them to clipboard if button is pressed. This button is used alongside the colors sliders to copy a palette

* Add copy npm lib
* Add clipboard copy component