### PR TITLE
Rebrand to ColorPix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# color-splash
+# ColorPix
 
 > Nuxt.js app to help users find inspiration from color palettes created via images from Unsplash
 

--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -47,7 +47,7 @@ export default {
       drawer: false,
       temporary: false,
       darkTheme: false,
-      title: 'Color Splash',
+      title: 'ColorPix',
       items: [
         {
           icon: 'mdi-home',
@@ -75,5 +75,5 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="stylus" scoped>
 </style>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,7 +8,10 @@ module.exports = {
   ** Headers of the page
   */
   head: {
-    title: pkg.name,
+    title: pkg.name
+      .split('-')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(''),
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "color-splash",
+  "name": "color-pix",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "color-splash",
+  "name": "color-pix",
   "version": "0.0.1",
   "description": "Nuxt.js app to help users find inspiration from color palettes created via images from Unsplash",
   "author": "Daniel Vernberg",


### PR DESCRIPTION
Motivation behind renaming from Color Splash to ColorPix:
* Cannot use the Unsplash API and have a name that plays with the Unsplash branding or name. Previous name "Color Splash" is to similar to "Unsplash"

This PR contains:
* Rename application from Color Splash to ColorPix