### PR TITLE
Enable real api methods

### DIFF
--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -34,7 +34,7 @@
       <v-spacer />
       <core-search-field />
       <v-spacer />
-      <core-menu-settings />
+      <!-- <core-menu-settings /> -->
     </v-toolbar>
   </div>
 </template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,13 +18,13 @@
         </v-flex>
       </v-layout>
       <v-layout v-if="imagesPopular" align-center justify-center>
-        <image-fetch-button text="Show more" :loading="loadingImages" @fetch="goTo('popular')" />
+        <image-fetch-button text="Show more" @fetch="goTo('popular')" />
       </v-layout>
     </div>
     <div v-if="imagesLatest">
       <h2 class="pl-4">
         <v-icon class="gray lighten-2">
-          mdi-history
+          mdi-clock-outline
         </v-icon>
         Latest
       </h2>
@@ -41,7 +41,7 @@
         </v-flex>
       </v-layout>
       <v-layout v-if="imagesLatest" align-center justify-center>
-        <image-fetch-button text="Show more" :loading="loadingImages" @fetch="goTo('latest')" />
+        <image-fetch-button text="Show more" @fetch="goTo('latest')" />
       </v-layout>
     </div>
   </v-container>

--- a/pages/list.vue
+++ b/pages/list.vue
@@ -52,7 +52,7 @@ export default {
   methods: {
     async getImagesList({ page = 1, perPage, orderBy }) {
       // TODO: Use real api request for fetching images by keyword
-      const { data } = await this.$api.getMockDataImageList({
+      const { data } = await this.$api.getImagesList({
         page,
         perPage,
         orderBy

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -49,7 +49,11 @@ export default {
   methods: {
     async getImagesByKeyword({ keyword, page = 1, perPage }) {
       // TODO: Use real api request for fetching images by keyword
-      const { data } = await this.$api.getMockDataImageList()
+      const { data } = await this.$api.getImagesByKeyword({
+        keyword,
+        page,
+        perPage
+      })
       return data
     },
     async loadMore({ page, perPage }) {


### PR DESCRIPTION
This PR removes mocking data through the api and instead use the real api methods. First version of application is to be released soon and mocking at this stage for this iteration is not needed anymore