### PR TITLE
Refactor color manipulation sliders to allow manipulation from more than one slider per color boxes

### DIFF
--- a/components/color/Slider.vue
+++ b/components/color/Slider.vue
@@ -1,44 +1,45 @@
+
 <template>
   <div>
-    <color-boxes :colors="hexValues" size="45px" :hover-effect="hoverEffect" />
-    <v-layout align-baseline>
-      <v-slider
-        v-model="sliderLevel"
-        :label="label"
-        :max="max"
-        :min="min"
-        thumb-label
-        :ticks="ticks"
-      />
-      <color-clipboard-copy :colors="hexValues" />
-    </v-layout>
+    <v-slider
+      v-model="sliderLevel"
+      :label="label"
+      :max="max"
+      :min="min"
+      thumb-label
+      :ticks="ticks"
+      @input="onChange"
+      @start="onStart"
+    />
   </div>
 </template>
 
 <script>
+/* eslint-disable no-console */
+import { availableTypes } from '@@/utils/colorManipulation'
 export default {
   props: {
-    hoverEffect: {
-      type: Boolean,
-      default: () => false
-    },
-    colors: {
-      type: Array,
-      default: () => []
+    label: {
+      type: String,
+      default: () => ''
     },
     type: {
       type: String,
       default: () => ''
     },
-    label: {
-      type: String,
-      default: () => ''
+    colors: {
+      type: Array,
+      default: () => []
     },
     max: {
       type: Number,
       default: () => 6
     },
     min: {
+      type: Number,
+      default: () => -6
+    },
+    default: {
       type: Number,
       default: () => 0
     },
@@ -53,12 +54,31 @@ export default {
   },
   data() {
     return {
-      sliderLevel: this.min
+      sliderLevel: this.default,
+      prevLevel: this.default
     }
   },
-  computed: {
-    hexValues() {
-      return this.colors.map(color => color[this.type](this.sliderLevel).hex())
+  mounted() {
+    if (!this.type) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Prop 'type' is required. The following types are allowed: ${availableTypes().join(
+          ', '
+        )}`
+      )
+    }
+  },
+  methods: {
+    onChange(evt) {
+      this.$emit('change', {
+        level: evt,
+        type: this.type,
+        shouldIncrement: evt >= this.prevLevel
+      })
+      this.prevLevel = evt
+    },
+    onStart(evt) {
+      this.prevLevel = evt
     }
   }
 }

--- a/components/image/Card.vue
+++ b/components/image/Card.vue
@@ -10,6 +10,8 @@
       <v-card-actions>
         <image-attribute-link :user="image.getUserInfo()" />
         <v-spacer />
+        <color-clipboard-copy :colors="hexValues" />
+
         <v-btn icon @click="showContent = !showContent">
           <v-icon>{{ showContent ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}</v-icon>
         </v-btn>

--- a/utils/colorManipulation.js
+++ b/utils/colorManipulation.js
@@ -1,0 +1,73 @@
+import chroma from 'chroma-js'
+
+/**
+ * Object that holds available color manipulation types
+ * and their respective manipulation methods above and below the 0 threshold
+ *
+ * The method arrays index 0 represents threshold < 0 and index 1 represents threshold > 0
+ */
+const TYPES = {
+  saturation: ['desaturate', 'saturate'],
+  brightness: ['darken', 'brighten']
+}
+
+/**
+ * Get list of available types of color manipulation
+ * @returns {Array}
+ */
+export function availableTypes() {
+  return Object.keys(TYPES)
+}
+
+/**
+ * Get available manipulation method name for a given type and threshold
+ * @param {String} type
+ * @param {Number} threshold
+ * @returns {String}
+ */
+export function getManipulationFromTypeAndThreshold({ type, threshold = 0 }) {
+  const manipulations = TYPES[type]
+  if (!manipulations) {
+    return ''
+  }
+  if (threshold < 0) {
+    return manipulations[0]
+  } else {
+    return manipulations[1]
+  }
+}
+
+/**
+ * Create and return a chroma object from a hex value
+ * @param {String} hex value
+ * @param {Object<Chroma>}
+ */
+export function chromaFromHex(hex) {
+  return chroma(hex)
+}
+
+/**
+ * Build a hex color array from chroma colors and passed color manipulation methods and values
+ * @param {Array<Chroma>} chromaColors array of chroma color objects
+ * @param {Array} manipulation representing chroma methods and levels to use
+ * @returns {Array} array of hex values
+ */
+export function getChangedHexValues({ chromaColors, manipulations }) {
+  const changedColors = []
+  chromaColors.forEach((color, index) => {
+    manipulations.forEach(manipulation => {
+      // No hex value exist for chrome color being iterated. Insert hex value from iterated chroma color
+      if (!changedColors[index]) {
+        const hexValue = color[manipulation.type](manipulation.level).hex()
+        changedColors[index] = hexValue
+      } else {
+        // Hex value already exist (i.e a hex value that has been manipulted). Manipulate that hex value further
+        const newChroma = chromaFromHex(changedColors[index])
+        changedColors[index] = newChroma[manipulation.type](
+          manipulation.level
+        ).hex()
+      }
+    })
+  })
+  return changedColors
+}

--- a/utils/colorManipulation.test.js
+++ b/utils/colorManipulation.test.js
@@ -1,0 +1,61 @@
+import {
+  availableTypes,
+  getManipulationFromTypeAndThreshold,
+  chromaFromHex,
+  getChangedHexValues
+} from './colorManipulation'
+describe('colorManipulation utils', () => {
+  describe('availableTypes()', () => {
+    it('should return available types', () => {
+      expect(availableTypes().length).toBeGreaterThan(1)
+    })
+  })
+
+  describe('getManipulationFromTypeAndThreshold', () => {
+    it('should return empty string of not finding any matching type', () => {
+      expect(
+        !getManipulationFromTypeAndThreshold({ type: 'false' })
+      ).toBeTruthy()
+    })
+
+    it('should return different types for different threshold', () => {
+      const type1 = getManipulationFromTypeAndThreshold({
+        type: 'saturation',
+        threshold: 1
+      })
+      const type2 = getManipulationFromTypeAndThreshold({
+        type: 'saturation',
+        threshold: -1
+      })
+      expect(type1).not.toMatch(type2)
+    })
+  })
+
+  describe('chromaFromHex()', () => {
+    it('should return a chroma object from a given hex value', () => {
+      const chromaObject = chromaFromHex('#eee')
+      expect(chromaObject).toBeDefined()
+      expect(chromaObject).toHaveProperty(
+        getManipulationFromTypeAndThreshold({
+          type: 'saturation',
+          threshold: -1
+        })
+      )
+    })
+  })
+
+  describe('GetChangedHexValues', () => {
+    it('should build new hex value array for a given manipulations criteria', () => {
+      const manipulations = [{ type: 'saturate', level: 2 }]
+      const originalHexValues = ['#eee', '#ee2', '#eee', '#ee2', '#eee', '#ee2']
+      const chromaObjects = originalHexValues.map(hex => chromaFromHex(hex))
+      const changedHexValues = getChangedHexValues({
+        chromaColors: chromaObjects,
+        manipulations
+      })
+      originalHexValues.map((hex, index) =>
+        expect(hex).not.toMatch(changedHexValues[index])
+      )
+    })
+  })
+})


### PR DESCRIPTION
This PR reduces complexity both in UX and in code by:
* UX: Color sliders are no longer seperated between tabs and each slider does now has it's own color boxes. Now the user can with a single slider saturate or desaturate at the same time as brighten AND darken the same hex colors.
* UX: Move copy button to the card actions slot. Previously it was hidden in each of the sliders - that were only visible once the user expanded a card
* Code: Reduce complexity in code by removing tabs altogether as a concept. Sliders are seperated from the color boxes for better re-use. Color manipulation util functions implemented to help reduce complexity of vue components (mainly card component that still does most of the heavy lifting and passes props to smaller components)