### PR TITLE
Prioritize latest images before popular on index page

### DIFF
--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -1,20 +1,8 @@
 <template>
   <div>
-    <v-navigation-drawer
-      v-model="drawer"
-      :clipped="clipped"
-      fixed
-      app
-      :temporary="temporary"
-    >
+    <v-navigation-drawer v-model="drawer" :clipped="clipped" fixed app :temporary="temporary">
       <v-list>
-        <v-list-tile
-          v-for="(item, i) in items"
-          :key="i"
-          :to="item.to"
-          router
-          exact
-        >
+        <v-list-tile v-for="(item, i) in items" :key="i" :to="item.to" router exact>
           <v-list-tile-action>
             <v-icon>{{ item.icon }}</v-icon>
           </v-list-tile-action>
@@ -24,11 +12,7 @@
         </v-list-tile>
       </v-list>
     </v-navigation-drawer>
-    <v-toolbar
-      :clipped-left="clipped"
-      fixed
-      app
-    >
+    <v-toolbar :clipped-left="clipped" fixed app>
       <v-toolbar-side-icon @click="drawer = !drawer" />
       <v-toolbar-title v-text="title" />
       <v-spacer />
@@ -55,14 +39,14 @@ export default {
           to: '/'
         },
         {
-          icon: 'mdi-fire',
-          title: 'Popular',
-          to: { path: '/list', query: { orderBy: 'popular' } }
-        },
-        {
           icon: 'mdi-clock-outline',
           title: 'Latest',
           to: { path: '/list', query: { orderBy: 'latest' } }
+        },
+        {
+          icon: 'mdi-fire',
+          title: 'Popular',
+          to: { path: '/list', query: { orderBy: 'popular' } }
         },
         {
           icon: 'mdi-information-variant',
@@ -75,5 +59,4 @@ export default {
 }
 </script>
 
-<style lang="stylus" scoped>
-</style>
+<style lang="stylus" scoped></style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -59,11 +59,11 @@ export default {
   },
   methods: {
     async getLatestImages() {
-      const { data } = await this.$api.getImagesLatest({ perPage: 4 })
+      const { data } = await this.$api.getImagesLatest({ perPage: 6 })
       this.imagesLatest = data
     },
     async getPopularImages() {
-      const { data } = await this.$api.getImagesPopular({ perPage: 4 })
+      const { data } = await this.$api.getImagesPopular({ perPage: 6 })
       this.imagesPopular = data
     },
     goTo(route) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,37 +1,15 @@
 <template>
   <v-container fluid>
-    <div v-if="imagesPopular">
-      <h2 class="pl-4">
-        <v-icon>mdi-fire</v-icon>
-        Popular
-      </h2>
-      <v-layout align-start row wrap>
-        <v-flex
-          v-for="imagePopular in imagesPopular"
-          :key="imagePopular.id"  
-          xl4
-          md6
-          xs12
-          pa-4
-        >
-          <image-card :image="imagePopular" />
-        </v-flex>
-      </v-layout>
-      <v-layout v-if="imagesPopular" align-center justify-center>
-        <image-fetch-button text="Show more" @fetch="goTo('popular')" />
-      </v-layout>
-    </div>
     <div v-if="imagesLatest">
       <h2 class="pl-4">
         <v-icon class="gray lighten-2">
           mdi-clock-outline
-        </v-icon>
-        Latest
+        </v-icon>Latest
       </h2>
       <v-layout align-start row wrap>
         <v-flex
           v-for="imageLatest in imagesLatest"
-          :key="imageLatest.id"  
+          :key="imageLatest.id"
           xl4
           md6
           xs12
@@ -42,6 +20,26 @@
       </v-layout>
       <v-layout v-if="imagesLatest" align-center justify-center>
         <image-fetch-button text="Show more" @fetch="goTo('latest')" />
+      </v-layout>
+    </div>
+    <div v-if="imagesPopular">
+      <h2 class="pl-4">
+        <v-icon>mdi-fire</v-icon>Popular
+      </h2>
+      <v-layout align-start row wrap>
+        <v-flex
+          v-for="imagePopular in imagesPopular"
+          :key="imagePopular.id"
+          xl4
+          md6
+          xs12
+          pa-4
+        >
+          <image-card :image="imagePopular" />
+        </v-flex>
+      </v-layout>
+      <v-layout v-if="imagesPopular" align-center justify-center>
+        <image-fetch-button text="Show more" @fetch="goTo('popular')" />
       </v-layout>
     </div>
   </v-container>


### PR DESCRIPTION
This PR changes the order (and amount) of popular and latest images on the index page and in the nav bar
* Display latest images first. After some usage it seems that the popular api does not update very often.
* Change amount of images to fetch from 4 to 6. 
* Some lint fixes