### PR TITLE
Implement lazy loading by scrolling when listing new/popular images

### DIFF
--- a/components/image/FetchButton.vue
+++ b/components/image/FetchButton.vue
@@ -29,11 +29,25 @@ export default {
     loading: {
       type: Boolean,
       default: false
+    },
+    lazy: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
     return {
       internalPage: this.page
+    }
+  },
+  created() {
+    if (this.lazy) {
+      window.addEventListener('scroll', this.handleScroll)
+    }
+  },
+  destroyed() {
+    if (this.lazy) {
+      window.removeEventListener('scroll', this.handleScroll)
     }
   },
   methods: {
@@ -43,11 +57,16 @@ export default {
     },
     stepPage() {
       this.internalPage += 1
+    },
+    handleScroll(evt) {
+      const positionY = this.$el.getBoundingClientRect().y
+      // Prevent multiple fetches by checking loading state (it's updated from the parent component)
+      if (positionY <= 1000 && !this.loading) {
+        this.fetch()
+      }
     }
   }
 }
 </script>
 
-<style lang="stylus" scoped>
-
-</style>
+<style lang="stylus" scoped></style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid>
+  <div>
     <div v-if="imagesLatest">
       <h2 class="pl-4">
         <v-icon class="gray lighten-2">
@@ -42,7 +42,7 @@
         <image-fetch-button text="Show more" @fetch="goTo('popular')" />
       </v-layout>
     </div>
-  </v-container>
+  </div>
 </template>
 
 <script>

--- a/pages/list.vue
+++ b/pages/list.vue
@@ -3,7 +3,7 @@
     <v-layout align-start row wrap>
       <v-flex
         v-for="(image, index) in images"
-        :key="index + image.id"  
+        :key="index + image.id"
         xl4
         md6
         xs12
@@ -14,7 +14,7 @@
     </v-layout>
 
     <v-layout v-if="hasImages" align-center justify-center>
-      <image-fetch-button :loading="loadingImages" @fetch="loadMore" />
+      <image-fetch-button :loading="loadingImages" :lazy="true" @fetch="loadMore" />
     </v-layout>
   </div>
 </template>

--- a/pages/list.vue
+++ b/pages/list.vue
@@ -51,7 +51,6 @@ export default {
   },
   methods: {
     async getImagesList({ page = 1, perPage, orderBy }) {
-      // TODO: Use real api request for fetching images by keyword
       const { data } = await this.$api.getImagesList({
         page,
         perPage,


### PR DESCRIPTION
This PR implements lazy loading images when scrolling the new/popular listings.
* Use a `lazy` boolean prop for FetchButton component. When true it will emit it's fetch event when button is about to come into scroll viewport
* Pass lazy=true as prop to FetchButton component in List page
* Remove redundant v-container component from index page