### PR TITLE
Implementation of masonry layout

### DIFF
--- a/components/core/NavigationDrawer.vue
+++ b/components/core/NavigationDrawer.vue
@@ -29,7 +29,7 @@ export default {
     return {
       clipped: true,
       drawer: false,
-      temporary: false,
+      temporary: true,
       darkTheme: false,
       title: 'ColorPix',
       items: [

--- a/components/image/Card.vue
+++ b/components/image/Card.vue
@@ -1,6 +1,6 @@
 <template>
   <v-hover>
-    <v-card slot-scope="{ hover }" :class="`elevation-${hover ? 18 : 0}`" class="elevation-0">
+    <v-card slot-scope="{ hover }" :class="`elevation-${hover ? 16 : 0}`" class="elevation-0 image-card">
       <v-img
         :src="image.getImageRegular()"
         :max-height="imageHeight"
@@ -135,5 +135,8 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="stylus" scoped>
+.image-card:hover
+  transform: translateY(-2px)
+
 </style>

--- a/components/image/Card.vue
+++ b/components/image/Card.vue
@@ -3,7 +3,7 @@
     <v-card slot-scope="{ hover }" :class="`elevation-${hover ? 18 : 0}`" class="elevation-0">
       <v-img
         :src="image.getImageRegular()"
-        :height="imageHeight"
+        :max-height="imageHeight"
         :lazy-src="image.getImageThumb()"
       />
       <color-boxes :colors="hexValues" />
@@ -49,7 +49,7 @@ export default {
     },
     imageHeight: {
       type: Number,
-      default: () => 250
+      default: () => 450
     }
   },
   data() {

--- a/components/layout/Masonry.vue
+++ b/components/layout/Masonry.vue
@@ -10,7 +10,7 @@ export default {
     cols: {
       type: [Object, String],
       default: () => {
-        return { default: 3, 1250: 2, 800: 1 }
+        return { default: 4, 1500: 3, 1250: 2, 800: 1 }
       }
     }
   }

--- a/components/layout/Masonry.vue
+++ b/components/layout/Masonry.vue
@@ -1,0 +1,23 @@
+<template>
+  <masonry class="masonry-wrapper" :cols="cols">
+    <slot />
+  </masonry>
+</template>
+
+<script>
+export default {
+  props: {
+    cols: {
+      type: [Object, String],
+      default: () => {
+        return { default: 3, 1250: 2, 800: 1 }
+      }
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.masonry-wrapper
+  width: 100%
+</style>

--- a/components/layout/MasonryImages.vue
+++ b/components/layout/MasonryImages.vue
@@ -1,0 +1,25 @@
+<template>
+  <layout-masonry>
+    <div
+      v-for="(image, index) in images"
+      :key="index + image.id"  
+      class="pa-4"
+    >
+      <image-card :image="image" />
+    </div>
+  </layout-masonry>
+</template>
+
+<script>
+export default {
+  props: {
+    images: {
+      type: Array,
+      default: () => []
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+</style>

--- a/components/layout/MasonryImages.vue
+++ b/components/layout/MasonryImages.vue
@@ -1,5 +1,5 @@
 <template>
-  <layout-masonry>
+  <layout-masonry :cols="cols">
     <div
       v-for="(image, index) in images"
       :key="index + image.id"  
@@ -16,6 +16,12 @@ export default {
     images: {
       type: Array,
       default: () => []
+    },
+    cols: {
+      type: [Object, String],
+      default: () => {
+        return { default: 4, 1500: 3, 1250: 2, 800: 1 }
+      }
     }
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -43,6 +43,7 @@ module.exports = {
   */
   plugins: [
     '@/plugins/vuetify',
+    '@/plugins/vueMasonry',
     '@/plugins/api',
     '@/plugins/componentRegistration'
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "color-pix",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14629,6 +14629,11 @@
         "vue-hot-reload-api": "^2.3.0",
         "vue-style-loader": "^4.1.0"
       }
+    },
+    "vue-masonry-css": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vue-masonry-css/-/vue-masonry-css-1.0.3.tgz",
+      "integrity": "sha512-viecHQiHVLez7HlYUQsv1wJb2MT/RDSzkDp6m3In41vPrk6OsBmT2qRE8LZqYIA4daIwrnx/Xm8h4fjOpuE3hw=="
     },
     "vue-meta": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node-vibrant": "^3.2.0-alpha",
     "nuxt": "^2.6.1",
     "unsplash-js": "^5.0.0",
+    "vue-masonry-css": "^1.0.3",
     "vuetify": "^1.5.8",
     "vuetify-loader": "^1.2.0"
   },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,15 +7,7 @@
         </v-icon>Latest
       </h2>
       <v-layout align-start row wrap>
-        <layout-masonry>
-          <div
-            v-for="imageLatest in imagesLatest"
-            :key="imageLatest.id"
-            class="pa-4"
-          >
-            <image-card :image="imageLatest" />
-          </div>
-        </layout-masonry>
+        <layout-masonry-images :images="imagesLatest" />
       </v-layout>
       <v-layout v-if="imagesLatest" align-center justify-center>
         <image-fetch-button text="Show more" @fetch="goTo('latest')" />
@@ -26,15 +18,7 @@
         <v-icon>mdi-fire</v-icon>Popular
       </h2>
       <v-layout align-start row wrap>
-        <layout-masonry>
-          <div
-            v-for="imagePopular in imagesPopular"
-            :key="imagePopular.id"
-            class="pa-4"
-          >
-            <image-card :image="imagePopular" />
-          </div>
-        </layout-masonry>
+        <layout-masonry-images :images="imagesPopular" />
       </v-layout>
       <v-layout v-if="imagesPopular" align-center justify-center>
         <image-fetch-button text="Show more" @fetch="goTo('popular')" />
@@ -57,11 +41,11 @@ export default {
   },
   methods: {
     async getLatestImages() {
-      const { data } = await this.$api.getImagesLatest({ perPage: 6 })
+      const { data } = await this.$api.getImagesLatest({ perPage: 8 })
       this.imagesLatest = data
     },
     async getPopularImages() {
-      const { data } = await this.$api.getImagesPopular({ perPage: 6 })
+      const { data } = await this.$api.getImagesPopular({ perPage: 8 })
       this.imagesPopular = data
     },
     goTo(route) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -7,16 +7,15 @@
         </v-icon>Latest
       </h2>
       <v-layout align-start row wrap>
-        <v-flex
-          v-for="imageLatest in imagesLatest"
-          :key="imageLatest.id"
-          xl4
-          md6
-          xs12
-          pa-4
-        >
-          <image-card :image="imageLatest" />
-        </v-flex>
+        <layout-masonry>
+          <div
+            v-for="imageLatest in imagesLatest"
+            :key="imageLatest.id"
+            class="pa-4"
+          >
+            <image-card :image="imageLatest" />
+          </div>
+        </layout-masonry>
       </v-layout>
       <v-layout v-if="imagesLatest" align-center justify-center>
         <image-fetch-button text="Show more" @fetch="goTo('latest')" />
@@ -27,16 +26,15 @@
         <v-icon>mdi-fire</v-icon>Popular
       </h2>
       <v-layout align-start row wrap>
-        <v-flex
-          v-for="imagePopular in imagesPopular"
-          :key="imagePopular.id"
-          xl4
-          md6
-          xs12
-          pa-4
-        >
-          <image-card :image="imagePopular" />
-        </v-flex>
+        <layout-masonry>
+          <div
+            v-for="imagePopular in imagesPopular"
+            :key="imagePopular.id"
+            class="pa-4"
+          >
+            <image-card :image="imagePopular" />
+          </div>
+        </layout-masonry>
       </v-layout>
       <v-layout v-if="imagesPopular" align-center justify-center>
         <image-fetch-button text="Show more" @fetch="goTo('popular')" />

--- a/pages/list.vue
+++ b/pages/list.vue
@@ -14,8 +14,7 @@ export default {
   data() {
     return {
       images: [],
-      loadingImages: false,
-      masonryCols: { default: 3, 1200: 2, 700: 1 }
+      loadingImages: false
     }
   },
   computed: {

--- a/pages/list.vue
+++ b/pages/list.vue
@@ -1,15 +1,7 @@
 <template>
   <div>
     <v-layout align-start row wrap>
-      <layout-masonry>
-        <div
-          v-for="(image, index) in images"
-          :key="index + image.id"  
-          class="pa-4"
-        >
-          <image-card :image="image" />
-        </div>
-      </layout-masonry>
+      <layout-masonry-images :images="images" />
     </v-layout>
     <v-layout v-if="hasImages" align-center justify-center>
       <image-fetch-button :loading="loadingImages" @fetch="loadMore" />

--- a/pages/list.vue
+++ b/pages/list.vue
@@ -1,18 +1,16 @@
 <template>
   <div>
     <v-layout align-start row wrap>
-      <v-flex
-        v-for="(image, index) in images"
-        :key="index + image.id"  
-        xl4
-        md6
-        xs12
-        pa-4
-      >
-        <image-card :image="image" />
-      </v-flex>
+      <layout-masonry>
+        <div
+          v-for="(image, index) in images"
+          :key="index + image.id"  
+          class="pa-4"
+        >
+          <image-card :image="image" />
+        </div>
+      </layout-masonry>
     </v-layout>
-
     <v-layout v-if="hasImages" align-center justify-center>
       <image-fetch-button :loading="loadingImages" @fetch="loadMore" />
     </v-layout>
@@ -24,7 +22,8 @@ export default {
   data() {
     return {
       images: [],
-      loadingImages: false
+      loadingImages: false,
+      masonryCols: { default: 3, 1200: 2, 700: 1 }
     }
   },
   computed: {

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,15 +1,7 @@
 <template>
   <div>
     <v-layout align-start row wrap>
-      <layout-masonry>
-        <div
-          v-for="(image, index) in images"
-          :key="index + image.id"  
-          class="pa-4"
-        >
-          <image-card :image="image" />
-        </div>
-      </layout-masonry>
+      <layout-masonry-images :images="images" />
     </v-layout>
 
     <v-layout v-if="hasImages" align-center justify-center>

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -1,16 +1,15 @@
 <template>
   <div>
     <v-layout align-start row wrap>
-      <v-flex
-        v-for="(image, index) in images"
-        :key="index + image.id"  
-        xl4
-        md6
-        xs12
-        pa-4
-      >
-        <image-card :image="image" />
-      </v-flex>
+      <layout-masonry>
+        <div
+          v-for="(image, index) in images"
+          :key="index + image.id"  
+          class="pa-4"
+        >
+          <image-card :image="image" />
+        </div>
+      </layout-masonry>
     </v-layout>
 
     <v-layout v-if="hasImages" align-center justify-center>

--- a/plugins/vueMasonry.js
+++ b/plugins/vueMasonry.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import VueMasonry from 'vue-masonry-css'
+
+Vue.use(VueMasonry)


### PR DESCRIPTION
This PR implements a masonry layout for displaying images. This somewhat removes the restriction of same sized images since the masonry layout helps reduce gaps in the card layout that otherwise is present when using a regular flexbox based layout.

* Added masonry nuxt plugin
* Added layout masonry component
* Implement masonry layout for index page and list page
* ScaleY transition on image cards to make the elevation effect more real