### PR TITLE
Added missing lazy prop in search page to allow lazy loading search results when scrolling

### DIFF
--- a/pages/search.vue
+++ b/pages/search.vue
@@ -5,7 +5,7 @@
     </v-layout>
 
     <v-layout v-if="hasImages" align-center justify-center>
-      <image-fetch-button :loading="loadingImages" @fetch="loadMore" />
+      <image-fetch-button :loading="loadingImages" :lazy="true" @fetch="loadMore" />
     </v-layout>
   </div>
 </template>


### PR DESCRIPTION
This PR adds missing `:lazy="true"` prop to fetch button in search page to allow lazy loading search result
* Add `:lazy="true"` prop to fetch button on search page