### PR TITLE
Subtle card transitions

### DIFF
--- a/components/image/Card.vue
+++ b/components/image/Card.vue
@@ -1,40 +1,48 @@
 <template>
   <v-hover v-slot:default="{ hover }">
-    <v-card :elevation="hover ? 16 : 0" class="image-card">
-      <v-img
-        :src="image.getImageRegular()"
-        :max-height="imageHeight"
-        :lazy-src="image.getImageThumb()"
-      />
-      <color-boxes :colors="hexValues" />
-      <v-card-actions>
-        <image-attribute-link :user="image.getUserInfo()" />
-        <v-spacer />
-        <color-clipboard-copy :colors="hexValues" />
-
-        <v-btn icon @click="showContent = !showContent">
-          <v-icon>
-            {{ showContent ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
-          </v-icon>
-        </v-btn>
-      </v-card-actions>
-      <v-slide-y-transition>
-        <v-card-text v-show="showContent">
-          <color-slider
-            :colors="colors"
-            label="Saturation"
-            type="saturation"
-            @change="onChangeSlider"
-          />
-          <color-slider
-            :colors="colors"
-            label="Brightness"
-            type="brightness"
-            @change="onChangeSlider"
-          />
-        </v-card-text>
-      </v-slide-y-transition>
-    </v-card>
+    <v-fade-transition tag="v-card">
+      <v-card
+        v-show="hasImgLoaded"
+        :elevation="hover ? 16 : 0"
+        class="image-card"
+      >
+        <v-img
+          :src="image.getImageRegular()"
+          :max-height="imageHeight"
+          :lazy-src="image.getImageThumb()"
+          @load="onImgLoad"
+        />
+        <v-fade-transition tag="color-boxes">
+          <color-boxes v-show="hexValues.length" :colors="hexValues" />
+        </v-fade-transition>
+        <v-card-actions>
+          <image-attribute-link :user="image.getUserInfo()" />
+          <v-spacer />
+          <color-clipboard-copy :colors="hexValues" />
+          <v-btn icon @click="showContent = !showContent">
+            <v-icon>
+              {{ showContent ? 'keyboard_arrow_up' : 'keyboard_arrow_down' }}
+            </v-icon>
+          </v-btn>
+        </v-card-actions>
+        <v-slide-y-transition>
+          <v-card-text v-show="showContent">
+            <color-slider
+              :colors="colors"
+              label="Saturation"
+              type="saturation"
+              @change="onChangeSlider"
+            />
+            <color-slider
+              :colors="colors"
+              label="Brightness"
+              type="brightness"
+              @change="onChangeSlider"
+            />
+          </v-card-text>
+        </v-slide-y-transition>
+      </v-card>
+    </v-fade-transition>
   </v-hover>
 </template>
 
@@ -59,7 +67,8 @@ export default {
       showContent: false,
       colors: [],
       colorManipulation: {},
-      hexValues: []
+      hexValues: [],
+      hasImgLoaded: false
     }
   },
   computed: {
@@ -132,6 +141,9 @@ export default {
     async getChromaColors() {
       const chromaColors = await this.image.getChromaColors()
       return [...chromaColors]
+    },
+    onImgLoad() {
+      this.hasImgLoaded = true
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -10,7 +10,7 @@
       <v-layout align-start row wrap>
         <layout-masonry-images :images="imagesLatest" />
       </v-layout>
-      <v-layout v-if="imagesLatest" align-center justify-center>
+      <v-layout v-if="hasLoadedLatest" align-center justify-center>
         <image-fetch-button text="Show more" @fetch="goTo('latest')" />
       </v-layout>
     </div>
@@ -22,7 +22,7 @@
       <v-layout align-start row wrap>
         <layout-masonry-images :images="imagesPopular" />
       </v-layout>
-      <v-layout v-if="imagesPopular" align-center justify-center>
+      <v-layout v-if="hasLoadedPopular" align-center justify-center>
         <image-fetch-button text="Show more" @fetch="goTo('popular')" />
       </v-layout>
     </div>
@@ -35,6 +35,14 @@ export default {
     return {
       imagesLatest: [],
       imagesPopular: []
+    }
+  },
+  computed: {
+    hasLoadedPopular() {
+      return this.imagesPopular.length
+    },
+    hasLoadedLatest() {
+      return this.imagesLatest.length
     }
   },
   mounted() {


### PR DESCRIPTION
This PR contains mostly some suble transitions element for the image card component
* Transitions to animate card with fade once the image has been fully loaded
* Transition to animate color boxes within cards once the hexValues are extracted from the image
* Only display load more buttons on index page when images has been loaded. Previously they would "flash" into view and be pushed down once images had been fetched