### PR TITLE
Remove settimeout from async/wait tests

### DIFF
--- a/server/services/imageList.test.js
+++ b/server/services/imageList.test.js
@@ -5,40 +5,32 @@ describe('imageList.service', () => {
     expect(fetchImageList).toBeDefined()
   })
 
-  it('should be able to retrieve a list of the latest images', () => {
-    setTimeout(async () => {
-      const images = await fetchImageList()
-      expect(images.length).toBeGreaterThan(1)
-      expect(images[0]).toHaveProperty('id')
-    })
+  it('should be able to retrieve a list of the latest images', async () => {
+    const images = await fetchImageList()
+    expect(images.length).toBeGreaterThan(1)
+    expect(images[0]).toHaveProperty('id')
   })
 
-  it('should be able to set size of image list to retrieve', () => {
-    setTimeout(async () => {
-      const images = await fetchImageList({ perPage: 5 })
-      expect(images.length).toBe(5)
-    })
+  it('should be able to set size of image list to retrieve', async () => {
+    const images = await fetchImageList({ perPage: 5 })
+    expect(images.length).toBe(5)
   })
 
-  it('should be able to retrieve different pages', () => {
-    setTimeout(async () => {
-      const imagesFirstPage = await fetchImageList({ page: 1 })
-      const imagesSecondPage = await fetchImageList({ page: 2 })
-      expect(imagesFirstPage[0].id).not.toEqual(imagesSecondPage[0].id)
-    })
+  it('should be able to retrieve different pages', async () => {
+    const imagesFirstPage = await fetchImageList({ page: 1 })
+    const imagesSecondPage = await fetchImageList({ page: 2 })
+    expect(imagesFirstPage[0].id).not.toEqual(imagesSecondPage[0].id)
   })
 
-  it('shoulb be able to set sort order', () => {
-    setTimeout(async () => {
-      const imagesLatest = await fetchImageList({ orderBy: 'latest' })
-      const imagesPopular = await fetchImageList({ orderBy: 'popular' })
-      const latestIds = imagesLatest.map(image => image.id)
-      const popularIds = imagesPopular.map(image => image.id)
-      // Lists can sometimes contain the same image. Determine different ids by cross reference the id lists
-      const overlapIds = latestIds.map(id => popularIds.includes(id))
-      expect(
-        overlapIds.filter(overlap => overlap).length < latestIds.length
-      ).toBe(true)
-    })
+  it('shoulb be able to set sort order', async () => {
+    const imagesLatest = await fetchImageList({ orderBy: 'latest' })
+    const imagesPopular = await fetchImageList({ orderBy: 'popular' })
+    const latestIds = imagesLatest.map(image => image.id)
+    const popularIds = imagesPopular.map(image => image.id)
+    // Lists can sometimes contain the same image. Determine different ids by cross reference the id lists
+    const overlapIds = latestIds.map(id => popularIds.includes(id))
+    expect(
+      overlapIds.filter(overlap => overlap).length < latestIds.length
+    ).toBe(true)
   })
 })

--- a/server/services/imageRandom.test.js
+++ b/server/services/imageRandom.test.js
@@ -5,13 +5,11 @@ describe('ImageRandom.service', () => {
     expect(fetchRandomImage).toBeDefined()
   })
 
-  it('should be able to retrieve a random image', () => {
-    setTimeout(async () => {
-      const image = await fetchRandomImage()
-      const imageSecond = await fetchRandomImage()
-      expect(image.id).toBeDefined()
-      expect(image.description).toBeDefined()
-      expect(image.id).not.toMatch(imageSecond.id)
-    })
+  it('should be able to retrieve a random image', async () => {
+    const image = await fetchRandomImage()
+    const imageSecond = await fetchRandomImage()
+    expect(image.id).toBeDefined()
+    expect(image.description).toBeDefined()
+    expect(image.id).not.toMatch(imageSecond.id)
   })
 })

--- a/server/services/imagesSearch.test.js
+++ b/server/services/imagesSearch.test.js
@@ -5,42 +5,34 @@ describe('ImageRandom.service', () => {
     expect(imagesSearch).toBeDefined()
   })
 
-  it('should be able to fetch default set of images for given keyword', () => {
-    setTimeout(async () => {
-      const images = await imagesSearch({ keyword: 'dogs' })
-      expect(images.results.length).toEqual(10)
-    })
+  it('should be able to fetch default set of images for given keyword', async () => {
+    const images = await imagesSearch({ keyword: 'dogs' })
+    expect(images.results.length).toEqual(10)
   })
 
-  it('should be able to set size of search result', () => {
-    setTimeout(async () => {
-      const images = await imagesSearch({ keyword: 'dogs', perPage: 5 })
-      expect(images.results.length).toEqual(5)
-    })
+  it('should be able to set size of search result', async () => {
+    const images = await imagesSearch({ keyword: 'dogs', perPage: 5 })
+    expect(images.results.length).toEqual(5)
   })
 
-  it('should be able to fetch multiple pages', () => {
-    setTimeout(async () => {
-      const imagesFirstPage = await imagesSearch({
-        keyword: 'dogs',
-        page: 1,
-        perPage: 10
-      })
-      const imagesSecondPage = await imagesSearch({
-        keyword: 'dogs',
-        page: 2,
-        perPage: 10
-      })
-      expect(imagesFirstPage.results[0].id).not.toMatch(
-        imagesSecondPage.results[0].id
-      )
+  it('should be able to fetch multiple pages', async () => {
+    const imagesFirstPage = await imagesSearch({
+      keyword: 'dogs',
+      page: 1,
+      perPage: 10
     })
+    const imagesSecondPage = await imagesSearch({
+      keyword: 'dogs',
+      page: 2,
+      perPage: 10
+    })
+    expect(imagesFirstPage.results[0].id).not.toMatch(
+      imagesSecondPage.results[0].id
+    )
   })
 
-  it('should return empty search result when no keyword is passed', () => {
-    setTimeout(async () => {
-      const images = await imagesSearch({ keyword: '' })
-      expect(images.results.length).toEqual(0)
-    })
+  it('should return empty search result when no keyword is passed', async () => {
+    const images = await imagesSearch({ keyword: '' })
+    expect(images.results.length).toEqual(0)
   })
 })

--- a/utils/ImagePalette.test.js
+++ b/utils/ImagePalette.test.js
@@ -13,28 +13,22 @@ describe('ImagePalette class', () => {
     inheritedMethods.map(method => expect(imagePalette[method]).toBeDefined())
   })
 
-  it('should get dominant colors from an image', () => {
-    setTimeout(async () => {
-      const colors = await imagePalette.getDominantColors()
-      expect(colors.length).toBeGreaterThan(0)
-    })
+  it('should get dominant colors from an image', async () => {
+    const colors = await imagePalette.getDominantColors()
+    expect(colors.length).toBeGreaterThan(0)
   })
 
-  it('should get dominant colors in hex format', () => {
-    setTimeout(async () => {
-      const colors = await imagePalette.getDominantColors()
-      expect(colors[0].includes('#')).toBeTruthy()
-    })
+  it('should get dominant colors in hex format', async () => {
+    const colors = await imagePalette.getDominantColors()
+    expect(colors[0].includes('#')).toBeTruthy()
   })
 
-  it('should get dominant colors as Chroma instances', () => {
-    setTimeout(async () => {
-      const colors = await imagePalette.getChromaColors()
-      const color = colors[0]
-      // Test that colors has inherited chroma prototype
-      expect(color.hex).toBeDefined()
-      expect(color.rgb).toBeDefined()
-      expect(color.saturate).toBeDefined()
-    })
+  it('should get dominant colors as Chroma instances', async () => {
+    const colors = await imagePalette.getChromaColors()
+    const color = colors[0]
+    // Test that colors has inherited chroma prototype
+    expect(color.hex).toBeDefined()
+    expect(color.rgb).toBeDefined()
+    expect(color.saturate).toBeDefined()
   })
 })


### PR DESCRIPTION
This PR removes settimeouts used in test with async/await syntaxes. The settimeout gave a false positive that the tests passed when in fact the jest expects did not validate at all.

The original problem was due to Travis CI not accessing environment keys needed to initiate a Unsplash API instance. Once Travis CI had the keys tests did not fail without the settimeouts (as they did before when they were not wrapped in settimeouts)