### PR TITLE
Make scroll threshold for lazily loading images a prop

### DIFF
--- a/components/image/FetchButton.vue
+++ b/components/image/FetchButton.vue
@@ -33,6 +33,10 @@ export default {
     lazy: {
       type: Boolean,
       default: false
+    },
+    scrollThreshold: {
+      type: Number,
+      default: 1300
     }
   },
   data() {
@@ -61,7 +65,7 @@ export default {
     handleScroll(evt) {
       const positionY = this.$el.getBoundingClientRect().y
       // Prevent multiple fetches by checking loading state (it's updated from the parent component)
-      if (positionY <= 1000 && !this.loading) {
+      if (positionY <= this.scrollThreshold && !this.loading) {
         this.fetch()
       }
     }

--- a/pages/collections.vue
+++ b/pages/collections.vue
@@ -27,8 +27,8 @@ export default {
     return {
       collections: [],
       loadingCollections: false,
-      imageCount: null, // Set to a number to have API fetch actual images attached to collections
-      collectionCount: 6
+      imageCount: 3,
+      collectionCount: 3
     }
   },
   computed: {
@@ -38,8 +38,7 @@ export default {
   },
   async mounted() {
     this.collections = await this.getCollections({
-      imageCount: this.imageCount,
-      perPage: this.collectionCount
+      imageCount: this.imageCount
     })
   },
   methods: {

--- a/pages/collections.vue
+++ b/pages/collections.vue
@@ -15,6 +15,7 @@
         :loading="loadingCollections"
         :lazy="true"
         :per-page="collectionCount"
+        :scroll-threshold="1800"
         @fetch="loadMore"
       />
     </v-layout>

--- a/pages/collections.vue
+++ b/pages/collections.vue
@@ -15,7 +15,6 @@
         :loading="loadingCollections"
         :lazy="true"
         :per-page="collectionCount"
-        :scroll-threshold="1800"
         @fetch="loadMore"
       />
     </v-layout>
@@ -28,8 +27,8 @@ export default {
     return {
       collections: [],
       loadingCollections: false,
-      imageCount: 3,
-      collectionCount: 3
+      imageCount: null, // Set to a number to have API fetch actual images attached to collections
+      collectionCount: 6
     }
   },
   computed: {
@@ -39,7 +38,8 @@ export default {
   },
   async mounted() {
     this.collections = await this.getCollections({
-      imageCount: this.imageCount
+      imageCount: this.imageCount,
+      perPage: this.collectionCount
     })
   },
   methods: {


### PR DESCRIPTION
This PR makes the scroll threshold position on the Y axis a prop with default value in the `FetchButton.vue` component. This prop is set default to 1300 with is 300 higher than what it previously was.

* Added a prop `scroll-threshold` to FetchButton.vue component
* Set `scroll-threshold` prop to 1800 on collections page. Bulk-fetching collections means more images has to be rendered on the page and bumping this prop means a higher chance that the next collections to be lazily loaded has fully rendered their images and color palettes when the user scrolls them into viewport. 