### PR TITLE
Set max width of collection description text

### DIFF
--- a/pages/collection/_id.vue
+++ b/pages/collection/_id.vue
@@ -17,7 +17,7 @@
         {{ collection.total_photos }} images.
         <image-attribute-link :user="collection.user" />
       </span>
-      <span v-if="collection.description" class="grey--text">
+      <span v-if="collection.description" class="grey--text description">
         {{ collection.description }}
       </span>
     </v-layout>
@@ -111,3 +111,8 @@ export default {
   }
 }
 </script>
+<style lang="sass" scoped>
+.description
+  max-width: 800px
+  text-align: center
+</style>


### PR DESCRIPTION
This PR sets max width of collection description text used for `/collection/:id` route component. Previously it had no max width and span entire browser viewport which was not as readable as it is with a max width