### PR TITLE
Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## What
+
+<!-- Describe what the PR is about and what changes are introduced with this PR. -->
+
+This PR changes/fixes/adds....
+
+## Types of changes
+
+What types of changes does this PR introduce?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if none of the other choices apply)
+
+## Checklist
+
+- [ ] Lint and unit tests pass locally
+- [ ] Travis CI checks passes
+- [ ] I have added necessary documentation (if appropriate)


### PR DESCRIPTION
This PR adds a pull request template to the repo inside a `.github` folder. This makes the PR descriptions more consistent