### PR TITLE
Only show breadcrumbs if user came from another route

### DIFF
--- a/pages/collection/_id.vue
+++ b/pages/collection/_id.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <v-layout align-center column>
-      <v-breadcrumbs :items="breadcrumbs" divider=">">
+      <v-breadcrumbs
+        v-if="cameFromAnotherRoute"
+        :items="breadcrumbs"
+        divider=">"
+      >
         <template v-slot:item="props">
           <v-breadcrumbs-item
             :to="props.item"
@@ -53,6 +57,9 @@ export default {
   computed: {
     hasLoadedAllImages() {
       return this.collection.total_photos === this.images.length
+    },
+    cameFromAnotherRoute() {
+      return this.breadcrumbs.length >= 2
     }
   },
   async mounted() {
@@ -98,7 +105,9 @@ export default {
     },
     setBreadcrumbs() {
       const previousRoute = this.$store.state.application.previousRoute
-      this.breadcrumbs.push(previousRoute)
+      if (previousRoute.path) {
+        this.breadcrumbs.push(previousRoute)
+      }
     },
     formatBreadcrumbName(name) {
       if (name.startsWith('search-')) {


### PR DESCRIPTION
## What

<!-- Describe what the PR is about and what changes are introduced with this PR. -->

This PR fixes a nullpointer bug on the collection id page where breadcrumbs caused a nullpointer error when `.startsWith()` tried to be performed on undefined (the previous route name was undefined if the user for example refreshed the browser on a collection id page)

## Types of changes

What types of changes does this PR introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally
- [x] Travis CI checks passes
- [ ] I have added necessary documentation (if appropriate)
